### PR TITLE
Make lua-releng return non-zero return code if it finds a problem

### DIFF
--- a/lua-releng
+++ b/lua-releng
@@ -21,13 +21,13 @@ sub w { warn  "$_[0]\n" if (!$silent) }
 # blank it is printed (and the program dies if stop_on_error is 1)
 sub blank {
     my ($command) = @_;
-    my $output = `$command`;
-    if ($output ne '') {
-        if ($stop_on_error) {
+    if ($stop_on_error) {
+        my $output = `$command`;
+        if ($output ne '') {
             die $output;
-        } else {
-            w($output);
         }
+    } else {
+        system($command);
     }
 }
 


### PR DESCRIPTION
This commit makes the following improvements to lua-releng:
1. Adds a -silent command-line parameter (it must be the first parameter
   on the command-line) which suppresses output (other than failures)
2. Makes it only look for a t/ directory if not files have been specified
   on the command-line
3. Removes commented-out and unused code
4. Calls 'die' whenever a problem is encountered so that this can be used
   in a test suite to fail if there are problems.
