### PR TITLE
add luac version check. this tool only support Lua 5.1

### DIFF
--- a/lua-releng
+++ b/lua-releng
@@ -14,6 +14,12 @@ my $silent = $opts{s};
 my $stop_on_error = $opts{e};
 my $no_long_line_check = $opts{L};
 
+my $check_lua_ver = "luac -v | awk '{print\$2}'| grep 5.1";
+my $output = `$check_lua_ver`;
+if ($output eq '') {
+    die "ERROR: lua-releng ONLY support Lua 5.1!\n";
+}
+
 if ($#ARGV != -1) {
     @luas = @ARGV;
 

--- a/lua-releng
+++ b/lua-releng
@@ -17,7 +17,7 @@ my $no_long_line_check = $opts{L};
 my $check_lua_ver = "luac -v | awk '{print\$2}'| grep 5.1";
 my $output = `$check_lua_ver`;
 if ($output eq '') {
-    die "ERROR: lua-releng ONLY support Lua 5.1!\n";
+    die "ERROR: lua-releng ONLY supports Lua 5.1!\n";
 }
 
 if ($#ARGV != -1) {


### PR DESCRIPTION
add luac version check.
Lua 5.2 is a quite different language and has different bytecodes. for example, Lua 5.2 change global get/sets from GETGLOBAL/SETGLOBAL opcodes to GETTABUP/SETTABUP. If you use Lua 5.2 to run this tool, you can not find global variables and no hint about wrong Lua version.